### PR TITLE
[pb-24] Import and export in JSON and CSV formats

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,14 @@
+"""Configuration and storage path management for the todo CLI."""
+
+import os
+from pathlib import Path
+
+
+def get_storage_path() -> Path:
+    """Return path to the todos JSON file, respecting TODO_FILE env override."""
+    env_path = os.environ.get("TODO_FILE")
+    if env_path:
+        return Path(env_path)
+    data_dir = Path.home() / ".local" / "share" / "todo-cli"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir / "todos.json"

--- a/formatter.py
+++ b/formatter.py
@@ -1,6 +1,6 @@
 """Terminal output formatting for todo items."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 
 
 def _status_char(todo: dict) -> str:

--- a/formatter.py
+++ b/formatter.py
@@ -1,0 +1,37 @@
+"""Terminal output formatting for todo items."""
+
+from datetime import datetime, timezone
+
+
+def _status_char(todo: dict) -> str:
+    return "x" if todo["done"] else " "
+
+
+def _created_label(todo: dict) -> str:
+    try:
+        dt = datetime.fromisoformat(todo["created_at"])
+        return dt.astimezone().strftime("%Y-%m-%d %H:%M")
+    except (KeyError, ValueError):
+        return "unknown"
+
+
+def format_todo(todo: dict) -> str:
+    """Single-line summary: '[x] #1  Buy milk'"""
+    return f"[{_status_char(todo)}] #{todo['id']:<4} {todo['title']}"
+
+
+def format_todo_list(todos: list[dict]) -> str:
+    if not todos:
+        return "No todos found."
+    return "\n".join(format_todo(t) for t in todos)
+
+
+def format_todo_detail(todo: dict) -> str:
+    """Multi-line detail view for a single todo."""
+    lines = [
+        f"ID:      {todo['id']}",
+        f"Title:   {todo['title']}",
+        f"Status:  {'done' if todo['done'] else 'pending'}",
+        f"Created: {_created_label(todo)}",
+    ]
+    return "\n".join(lines)

--- a/formatter.py
+++ b/formatter.py
@@ -15,9 +15,14 @@ def _created_label(todo: dict) -> str:
         return "unknown"
 
 
+def _tags_label(todo: dict) -> str:
+    tags = todo.get("tags", [])
+    return f"  [{', '.join(tags)}]" if tags else ""
+
+
 def format_todo(todo: dict) -> str:
-    """Single-line summary: '[x] #1  Buy milk'"""
-    return f"[{_status_char(todo)}] #{todo['id']:<4} {todo['title']}"
+    """Single-line summary: '[x] #1  Buy milk  [tag1, tag2]'"""
+    return f"[{_status_char(todo)}] #{todo['id']:<4} {todo['title']}{_tags_label(todo)}"
 
 
 def format_todo_list(todos: list[dict]) -> str:
@@ -28,10 +33,12 @@ def format_todo_list(todos: list[dict]) -> str:
 
 def format_todo_detail(todo: dict) -> str:
     """Multi-line detail view for a single todo."""
+    tags = todo.get("tags", [])
     lines = [
         f"ID:      {todo['id']}",
         f"Title:   {todo['title']}",
         f"Status:  {'done' if todo['done'] else 'pending'}",
         f"Created: {_created_label(todo)}",
+        f"Tags:    {', '.join(tags) if tags else '(none)'}",
     ]
     return "\n".join(lines)

--- a/importexport.py
+++ b/importexport.py
@@ -1,0 +1,126 @@
+"""Import and export todos in JSON and CSV formats."""
+
+import csv
+import io
+import json
+from pathlib import Path
+from typing import Optional
+
+import todo as todo_module
+
+
+def _detect_format(path: Path, explicit: Optional[str]) -> str:
+    if explicit:
+        return explicit.lower()
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return "csv"
+    return "json"
+
+
+def export_todos(path: Path, fmt: Optional[str] = None) -> int:
+    """Write all todos to *path* in the given format. Returns count written."""
+    fmt = _detect_format(path, fmt)
+    items = todo_module.load_todos()
+
+    if fmt == "csv":
+        with path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(
+                f,
+                fieldnames=["id", "title", "done", "created_at", "tags"],
+            )
+            writer.writeheader()
+            for item in items:
+                writer.writerow({
+                    "id": item["id"],
+                    "title": item["title"],
+                    "done": item["done"],
+                    "created_at": item.get("created_at", ""),
+                    "tags": ",".join(item.get("tags", [])),
+                })
+    else:
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(items, f, indent=2)
+
+    return len(items)
+
+
+def import_todos(path: Path, fmt: Optional[str] = None) -> tuple[int, int]:
+    """Read todos from *path* and merge into the store, skipping duplicates by ID.
+
+    Returns (imported_count, skipped_count).
+    """
+    fmt = _detect_format(path, fmt)
+
+    if fmt == "csv":
+        incoming = _read_csv(path)
+    else:
+        incoming = _read_json(path)
+
+    data = todo_module._load_raw()
+    existing_ids = {t["id"] for t in data["todos"]}
+
+    imported = 0
+    skipped = 0
+    for item in incoming:
+        if item["id"] in existing_ids:
+            skipped += 1
+            continue
+        data["todos"].append(item)
+        existing_ids.add(item["id"])
+        if item["id"] >= data["next_id"]:
+            data["next_id"] = item["id"] + 1
+        imported += 1
+
+    todo_module._save_raw(data)
+    return imported, skipped
+
+
+def _read_json(path: Path) -> list[dict]:
+    with path.open(encoding="utf-8") as f:
+        items = json.load(f)
+    if not isinstance(items, list):
+        raise ValueError("JSON import file must contain a top-level array.")
+    result = []
+    for item in items:
+        result.append(_normalise(item))
+    return result
+
+
+def _read_csv(path: Path) -> list[dict]:
+    result = []
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            result.append(_normalise_csv(row))
+    return result
+
+
+def _normalise(item: dict) -> dict:
+    """Validate and normalise a todo dict from JSON."""
+    if "id" not in item:
+        raise ValueError(f"Todo entry missing 'id' field: {item!r}")
+    return {
+        "id": int(item["id"]),
+        "title": str(item.get("title", "")),
+        "done": bool(item.get("done", False)),
+        "created_at": str(item.get("created_at", "")),
+        "tags": list(item.get("tags", [])),
+    }
+
+
+def _normalise_csv(row: dict) -> dict:
+    """Convert a CSV row into a todo dict."""
+    if "id" not in row or not row["id"]:
+        raise ValueError(f"CSV row missing 'id': {row!r}")
+    tags_raw = row.get("tags", "")
+    tags = [t.strip() for t in tags_raw.split(",") if t.strip()] if tags_raw else []
+    done_raw = row.get("done", "False")
+    done = done_raw.strip().lower() in ("true", "1", "yes")
+    return {
+        "id": int(row["id"]),
+        "title": str(row.get("title", "")),
+        "done": done,
+        "created_at": str(row.get("created_at", "")),
+        "tags": tags,
+    }

--- a/main.py
+++ b/main.py
@@ -12,16 +12,17 @@ import validator
 def cmd_add(args: argparse.Namespace) -> int:
     try:
         title = validator.validate_title(" ".join(args.title))
+        tags = validator.validate_tags(args.tags or "")
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    item = todo.add_todo(title)
+    item = todo.add_todo(title, tags=tags)
     print(f"Added: {formatter.format_todo(item)}")
     return 0
 
 
 def cmd_list(args: argparse.Namespace) -> int:
-    items = todo.list_todos(show_done=args.all)
+    items = todo.list_todos(show_done=args.all, tag=args.tag)
     print(formatter.format_todo_list(items))
     return 0
 
@@ -81,12 +82,20 @@ def build_parser() -> argparse.ArgumentParser:
     # add
     p_add = sub.add_parser("add", help="Add a new todo item.")
     p_add.add_argument("title", nargs="+", help="Title of the todo item.")
+    p_add.add_argument(
+        "--tags", metavar="TAGS",
+        help="Comma-separated tags (e.g. 'work,urgent').",
+    )
     p_add.set_defaults(func=cmd_add)
 
     # list
     p_list = sub.add_parser("list", help="List todo items.")
     p_list.add_argument(
         "--all", action="store_true", help="Include completed todos."
+    )
+    p_list.add_argument(
+        "--tag", metavar="TAG",
+        help="Filter to todos that have this tag.",
     )
     p_list.set_defaults(func=cmd_list)
 

--- a/main.py
+++ b/main.py
@@ -57,6 +57,12 @@ def cmd_delete(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_search(args: argparse.Namespace) -> int:
+    items = todo.search_todos(args.query)
+    print(formatter.format_todo_list(items))
+    return 0
+
+
 def cmd_show(args: argparse.Namespace) -> int:
     try:
         todo_id = validator.validate_id(args.id)
@@ -113,6 +119,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_show = sub.add_parser("show", help="Show detail for a todo item.")
     p_show.add_argument("id", help="ID of the todo to show.")
     p_show.set_defaults(func=cmd_show)
+
+    # search
+    p_search = sub.add_parser("search", help="Search todos by title or tag.")
+    p_search.add_argument("query", help="Substring to search for (case-insensitive).")
+    p_search.set_defaults(func=cmd_search)
 
     return parser
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Todo CLI — entry point."""
+
+import argparse
+import sys
+
+import formatter
+import todo
+import validator
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    try:
+        title = validator.validate_title(" ".join(args.title))
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    item = todo.add_todo(title)
+    print(f"Added: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    items = todo.list_todos(show_done=args.all)
+    print(formatter.format_todo_list(items))
+    return 0
+
+
+def cmd_done(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    try:
+        item = todo.mark_done(todo_id)
+    except KeyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Marked done: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    try:
+        item = todo.delete_todo(todo_id)
+    except KeyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Deleted: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    item = todo.get_todo(todo_id)
+    if item is None:
+        print(f"Error: Todo #{todo_id} not found.", file=sys.stderr)
+        return 1
+    print(formatter.format_todo_detail(item))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="todo",
+        description="A simple command-line todo manager.",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="<command>")
+    sub.required = True
+
+    # add
+    p_add = sub.add_parser("add", help="Add a new todo item.")
+    p_add.add_argument("title", nargs="+", help="Title of the todo item.")
+    p_add.set_defaults(func=cmd_add)
+
+    # list
+    p_list = sub.add_parser("list", help="List todo items.")
+    p_list.add_argument(
+        "--all", action="store_true", help="Include completed todos."
+    )
+    p_list.set_defaults(func=cmd_list)
+
+    # done
+    p_done = sub.add_parser("done", help="Mark a todo as done.")
+    p_done.add_argument("id", help="ID of the todo to mark done.")
+    p_done.set_defaults(func=cmd_done)
+
+    # delete
+    p_del = sub.add_parser("delete", help="Delete a todo item.")
+    p_del.add_argument("id", help="ID of the todo to delete.")
+    p_del.set_defaults(func=cmd_delete)
+
+    # show
+    p_show = sub.add_parser("show", help="Show detail for a todo item.")
+    p_show.add_argument("id", help="ID of the todo to show.")
+    p_show.set_defaults(func=cmd_show)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/main.py
+++ b/main.py
@@ -3,8 +3,10 @@
 
 import argparse
 import sys
+from pathlib import Path
 
 import formatter
+import importexport
 import todo
 import validator
 
@@ -77,6 +79,32 @@ def cmd_show(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_export(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    try:
+        count = importexport.export_todos(path, fmt=args.format)
+    except (OSError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    fmt = args.format or path.suffix.lstrip(".") or "json"
+    print(f"Exported {count} todo(s) to {path} ({fmt})")
+    return 0
+
+
+def cmd_import(args: argparse.Namespace) -> int:
+    path = Path(args.file)
+    if not path.exists():
+        print(f"Error: File not found: {path}", file=sys.stderr)
+        return 1
+    try:
+        imported, skipped = importexport.import_todos(path, fmt=args.format)
+    except (OSError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Imported {imported} todo(s), skipped {skipped} duplicate(s).")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="todo",
@@ -124,6 +152,24 @@ def build_parser() -> argparse.ArgumentParser:
     p_search = sub.add_parser("search", help="Search todos by title or tag.")
     p_search.add_argument("query", help="Substring to search for (case-insensitive).")
     p_search.set_defaults(func=cmd_search)
+
+    # export
+    p_export = sub.add_parser("export", help="Export all todos to a JSON or CSV file.")
+    p_export.add_argument("file", help="Destination file path.")
+    p_export.add_argument(
+        "--format", choices=["json", "csv"], metavar="FORMAT",
+        help="Output format: json or csv (default: inferred from file extension).",
+    )
+    p_export.set_defaults(func=cmd_export)
+
+    # import
+    p_import = sub.add_parser("import", help="Import todos from a JSON or CSV file.")
+    p_import.add_argument("file", help="Source file path.")
+    p_import.add_argument(
+        "--format", choices=["json", "csv"], metavar="FORMAT",
+        help="File format: json or csv (default: inferred from file extension).",
+    )
+    p_import.set_defaults(func=cmd_import)
 
     return parser
 

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ def cmd_done(args: argparse.Namespace) -> int:
         return 1
     try:
         item = todo.mark_done(todo_id)
-    except KeyError as e:
+    except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"Marked done: {formatter.format_todo(item)}")
@@ -52,7 +52,7 @@ def cmd_delete(args: argparse.Namespace) -> int:
         return 1
     try:
         item = todo.delete_todo(todo_id)
-    except KeyError as e:
+    except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"Deleted: {formatter.format_todo(item)}")

--- a/test_importexport.py
+++ b/test_importexport.py
@@ -1,0 +1,231 @@
+"""Tests for import/export functionality."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Ensure the project root is on the path
+sys.path.insert(0, str(Path(__file__).parent))
+
+import importexport
+import todo as todo_module
+
+
+class ExportImportBase(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._store = Path(self._tmpdir.name) / "todos.json"
+        os.environ["TODO_FILE"] = str(self._store)
+
+    def tearDown(self):
+        os.environ.pop("TODO_FILE", None)
+        self._tmpdir.cleanup()
+
+    def _seed(self, *titles):
+        for title in titles:
+            todo_module.add_todo(title)
+
+
+class TestExportJSON(ExportImportBase):
+    def test_exports_all_todos(self):
+        self._seed("Alpha", "Beta")
+        out = Path(self._tmpdir.name) / "out.json"
+        count = importexport.export_todos(out)
+        self.assertEqual(count, 2)
+        data = json.loads(out.read_text())
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["title"], "Alpha")
+        self.assertEqual(data[1]["title"], "Beta")
+
+    def test_exports_empty_store(self):
+        out = Path(self._tmpdir.name) / "out.json"
+        count = importexport.export_todos(out)
+        self.assertEqual(count, 0)
+        self.assertEqual(json.loads(out.read_text()), [])
+
+    def test_format_inferred_from_extension(self):
+        self._seed("X")
+        out = Path(self._tmpdir.name) / "todos.json"
+        importexport.export_todos(out)
+        data = json.loads(out.read_text())
+        self.assertIsInstance(data, list)
+
+    def test_explicit_format_overrides_extension(self):
+        self._seed("X")
+        out = Path(self._tmpdir.name) / "todos.txt"
+        importexport.export_todos(out, fmt="json")
+        data = json.loads(out.read_text())
+        self.assertIsInstance(data, list)
+
+
+class TestExportCSV(ExportImportBase):
+    def _read_csv_rows(self, path: Path):
+        import csv
+        with path.open(newline="") as f:
+            return list(csv.DictReader(f))
+
+    def test_exports_csv(self):
+        self._seed("Alpha", "Beta")
+        todo_module.mark_done(1)
+        out = Path(self._tmpdir.name) / "out.csv"
+        count = importexport.export_todos(out)
+        self.assertEqual(count, 2)
+        rows = self._read_csv_rows(out)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["title"], "Alpha")
+        self.assertEqual(rows[0]["done"], "True")
+        self.assertEqual(rows[1]["title"], "Beta")
+        self.assertEqual(rows[1]["done"], "False")
+
+    def test_tags_serialised_comma_separated(self):
+        todo_module.add_todo("Tagged", tags=["a", "b"])
+        out = Path(self._tmpdir.name) / "out.csv"
+        importexport.export_todos(out)
+        rows = self._read_csv_rows(out)
+        self.assertEqual(rows[0]["tags"], "a,b")
+
+    def test_empty_tags(self):
+        self._seed("No tags")
+        out = Path(self._tmpdir.name) / "out.csv"
+        importexport.export_todos(out)
+        rows = self._read_csv_rows(out)
+        self.assertEqual(rows[0]["tags"], "")
+
+
+class TestImportJSON(ExportImportBase):
+    def _write_json(self, items: list) -> Path:
+        path = Path(self._tmpdir.name) / "import.json"
+        path.write_text(json.dumps(items))
+        return path
+
+    def test_imports_new_todos(self):
+        path = self._write_json([
+            {"id": 1, "title": "Foo", "done": False, "created_at": "", "tags": []},
+            {"id": 2, "title": "Bar", "done": True, "created_at": "", "tags": ["x"]},
+        ])
+        imported, skipped = importexport.import_todos(path)
+        self.assertEqual(imported, 2)
+        self.assertEqual(skipped, 0)
+        todos = todo_module.load_todos()
+        self.assertEqual(len(todos), 2)
+
+    def test_skips_duplicate_ids(self):
+        self._seed("Existing")  # id=1
+        path = self._write_json([
+            {"id": 1, "title": "Should be skipped", "done": False, "created_at": "", "tags": []},
+            {"id": 2, "title": "New one", "done": False, "created_at": "", "tags": []},
+        ])
+        imported, skipped = importexport.import_todos(path)
+        self.assertEqual(imported, 1)
+        self.assertEqual(skipped, 1)
+        todos = todo_module.load_todos()
+        titles = [t["title"] for t in todos]
+        self.assertIn("Existing", titles)
+        self.assertIn("New one", titles)
+        self.assertNotIn("Should be skipped", titles)
+
+    def test_updates_next_id(self):
+        path = self._write_json([
+            {"id": 99, "title": "High ID", "done": False, "created_at": "", "tags": []},
+        ])
+        importexport.import_todos(path)
+        new = todo_module.add_todo("After import")
+        self.assertEqual(new["id"], 100)
+
+    def test_rejects_non_array(self):
+        path = Path(self._tmpdir.name) / "bad.json"
+        path.write_text(json.dumps({"id": 1, "title": "oops"}))
+        with self.assertRaises(ValueError):
+            importexport.import_todos(path)
+
+    def test_rejects_missing_id(self):
+        path = self._write_json([{"title": "No id"}])
+        with self.assertRaises(ValueError):
+            importexport.import_todos(path)
+
+
+class TestImportCSV(ExportImportBase):
+    def _write_csv(self, rows: list[dict]) -> Path:
+        import csv
+        path = Path(self._tmpdir.name) / "import.csv"
+        with path.open("w", newline="") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=["id", "title", "done", "created_at", "tags"]
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+        return path
+
+    def test_imports_csv(self):
+        path = self._write_csv([
+            {"id": 1, "title": "Task A", "done": "False", "created_at": "", "tags": ""},
+            {"id": 2, "title": "Task B", "done": "True", "created_at": "", "tags": "x,y"},
+        ])
+        imported, skipped = importexport.import_todos(path)
+        self.assertEqual(imported, 2)
+        todos = todo_module.load_todos()
+        self.assertEqual(todos[1]["tags"], ["x", "y"])
+        self.assertTrue(todos[1]["done"])
+
+    def test_skips_duplicate_ids_csv(self):
+        self._seed("Original")  # id=1
+        path = self._write_csv([
+            {"id": 1, "title": "Dup", "done": "False", "created_at": "", "tags": ""},
+        ])
+        imported, skipped = importexport.import_todos(path)
+        self.assertEqual(imported, 0)
+        self.assertEqual(skipped, 1)
+
+    def test_csv_done_variations(self):
+        path = self._write_csv([
+            {"id": 1, "title": "T1", "done": "true", "created_at": "", "tags": ""},
+            {"id": 2, "title": "T2", "done": "1", "created_at": "", "tags": ""},
+            {"id": 3, "title": "T3", "done": "yes", "created_at": "", "tags": ""},
+            {"id": 4, "title": "T4", "done": "False", "created_at": "", "tags": ""},
+        ])
+        importexport.import_todos(path)
+        todos = {t["id"]: t for t in todo_module.load_todos()}
+        self.assertTrue(todos[1]["done"])
+        self.assertTrue(todos[2]["done"])
+        self.assertTrue(todos[3]["done"])
+        self.assertFalse(todos[4]["done"])
+
+
+class TestRoundTrip(ExportImportBase):
+    def test_json_roundtrip(self):
+        todo_module.add_todo("Alpha", tags=["a"])
+        todo_module.add_todo("Beta")
+        todo_module.mark_done(2)
+        export_path = Path(self._tmpdir.name) / "rt.json"
+        importexport.export_todos(export_path)
+
+        # Import into a fresh store
+        new_store = Path(self._tmpdir.name) / "new.json"
+        os.environ["TODO_FILE"] = str(new_store)
+        importexport.import_todos(export_path)
+        todos = todo_module.load_todos()
+        self.assertEqual(len(todos), 2)
+        t1 = next(t for t in todos if t["id"] == 1)
+        self.assertEqual(t1["title"], "Alpha")
+        self.assertEqual(t1["tags"], ["a"])
+        t2 = next(t for t in todos if t["id"] == 2)
+        self.assertTrue(t2["done"])
+
+    def test_csv_roundtrip(self):
+        todo_module.add_todo("Alpha", tags=["x", "y"])
+        export_path = Path(self._tmpdir.name) / "rt.csv"
+        importexport.export_todos(export_path)
+
+        new_store = Path(self._tmpdir.name) / "new.json"
+        os.environ["TODO_FILE"] = str(new_store)
+        importexport.import_todos(export_path)
+        todos = todo_module.load_todos()
+        self.assertEqual(todos[0]["title"], "Alpha")
+        self.assertEqual(todos[0]["tags"], ["x", "y"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,74 @@
+"""Core todo CRUD operations backed by a JSON file."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from config import get_storage_path
+
+
+def _load_raw() -> dict:
+    path = get_storage_path()
+    if not path.exists():
+        return {"next_id": 1, "todos": []}
+    with path.open() as f:
+        return json.load(f)
+
+
+def _save_raw(data: dict) -> None:
+    path = get_storage_path()
+    with path.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_todos() -> list[dict]:
+    return _load_raw()["todos"]
+
+
+def add_todo(title: str) -> dict:
+    data = _load_raw()
+    todo = {
+        "id": data["next_id"],
+        "title": title,
+        "done": False,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    data["todos"].append(todo)
+    data["next_id"] += 1
+    _save_raw(data)
+    return todo
+
+
+def get_todo(todo_id: int) -> Optional[dict]:
+    for todo in load_todos():
+        if todo["id"] == todo_id:
+            return todo
+    return None
+
+
+def list_todos(show_done: bool = False) -> list[dict]:
+    todos = load_todos()
+    if not show_done:
+        todos = [t for t in todos if not t["done"]]
+    return todos
+
+
+def mark_done(todo_id: int) -> dict:
+    data = _load_raw()
+    for todo in data["todos"]:
+        if todo["id"] == todo_id:
+            todo["done"] = True
+            _save_raw(data)
+            return todo
+    raise KeyError(f"Todo #{todo_id} not found.")
+
+
+def delete_todo(todo_id: int) -> dict:
+    data = _load_raw()
+    for i, todo in enumerate(data["todos"]):
+        if todo["id"] == todo_id:
+            removed = data["todos"].pop(i)
+            _save_raw(data)
+            return removed
+    raise KeyError(f"Todo #{todo_id} not found.")

--- a/todo.py
+++ b/todo.py
@@ -57,6 +57,18 @@ def list_todos(show_done: bool = False, tag: Optional[str] = None) -> list[dict]
     return todos
 
 
+def search_todos(query: str) -> list[dict]:
+    q = query.lower()
+    results = []
+    for todo in load_todos():
+        if q in todo["title"].lower():
+            results.append(todo)
+            continue
+        if any(q in tag.lower() for tag in todo.get("tags", [])):
+            results.append(todo)
+    return results
+
+
 def mark_done(todo_id: int) -> dict:
     data = _load_raw()
     for todo in data["todos"]:

--- a/todo.py
+++ b/todo.py
@@ -26,13 +26,14 @@ def load_todos() -> list[dict]:
     return _load_raw()["todos"]
 
 
-def add_todo(title: str) -> dict:
+def add_todo(title: str, tags: Optional[list[str]] = None) -> dict:
     data = _load_raw()
     todo = {
         "id": data["next_id"],
         "title": title,
         "done": False,
         "created_at": datetime.now(timezone.utc).isoformat(),
+        "tags": tags or [],
     }
     data["todos"].append(todo)
     data["next_id"] += 1
@@ -47,10 +48,12 @@ def get_todo(todo_id: int) -> Optional[dict]:
     return None
 
 
-def list_todos(show_done: bool = False) -> list[dict]:
+def list_todos(show_done: bool = False, tag: Optional[str] = None) -> list[dict]:
     todos = load_todos()
     if not show_done:
         todos = [t for t in todos if not t["done"]]
+    if tag:
+        todos = [t for t in todos if tag in t.get("tags", [])]
     return todos
 
 

--- a/todo.py
+++ b/todo.py
@@ -76,7 +76,7 @@ def mark_done(todo_id: int) -> dict:
             todo["done"] = True
             _save_raw(data)
             return todo
-    raise KeyError(f"Todo #{todo_id} not found.")
+    raise ValueError(f"Todo #{todo_id} not found.")
 
 
 def delete_todo(todo_id: int) -> dict:
@@ -86,4 +86,4 @@ def delete_todo(todo_id: int) -> dict:
             removed = data["todos"].pop(i)
             _save_raw(data)
             return removed
-    raise KeyError(f"Todo #{todo_id} not found.")
+    raise ValueError(f"Todo #{todo_id} not found.")

--- a/validator.py
+++ b/validator.py
@@ -1,0 +1,20 @@
+"""Input validation for the todo CLI."""
+
+
+def validate_title(title: str) -> str:
+    """Return stripped title, raising ValueError if blank."""
+    stripped = title.strip()
+    if not stripped:
+        raise ValueError("Todo title cannot be empty.")
+    return stripped
+
+
+def validate_id(raw_id: str) -> int:
+    """Return integer id, raising ValueError if not a positive integer."""
+    try:
+        todo_id = int(raw_id)
+    except (TypeError, ValueError):
+        raise ValueError(f"Invalid id '{raw_id}': must be a positive integer.")
+    if todo_id < 1:
+        raise ValueError(f"Invalid id '{raw_id}': must be a positive integer.")
+    return todo_id

--- a/validator.py
+++ b/validator.py
@@ -9,6 +9,14 @@ def validate_title(title: str) -> str:
     return stripped
 
 
+def validate_tags(raw_tags: str) -> list[str]:
+    """Parse comma-separated tags, stripping whitespace. Returns empty list for blank input."""
+    if not raw_tags or not raw_tags.strip():
+        return []
+    tags = [t.strip() for t in raw_tags.split(",")]
+    return [t for t in tags if t]
+
+
 def validate_id(raw_id: str) -> int:
     """Return integer id, raising ValueError if not a positive integer."""
     try:


### PR DESCRIPTION
## Summary

Add import/export subcommands. Export writes all todos to a file in JSON or CSV. Import reads a file and merges into the store, skipping duplicates by ID.


Ticket: pb-24