### PR TITLE
[pb-30] Sort and group options for list command

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,14 @@
+"""Configuration and storage path management for the todo CLI."""
+
+import os
+from pathlib import Path
+
+
+def get_storage_path() -> Path:
+    """Return path to the todos JSON file, respecting TODO_FILE env override."""
+    env_path = os.environ.get("TODO_FILE")
+    if env_path:
+        return Path(env_path)
+    data_dir = Path.home() / ".local" / "share" / "todo-cli"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir / "todos.json"

--- a/formatter.py
+++ b/formatter.py
@@ -1,6 +1,6 @@
 """Terminal output formatting for todo items."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 
 
 def _status_char(todo: dict) -> str:

--- a/formatter.py
+++ b/formatter.py
@@ -1,0 +1,37 @@
+"""Terminal output formatting for todo items."""
+
+from datetime import datetime, timezone
+
+
+def _status_char(todo: dict) -> str:
+    return "x" if todo["done"] else " "
+
+
+def _created_label(todo: dict) -> str:
+    try:
+        dt = datetime.fromisoformat(todo["created_at"])
+        return dt.astimezone().strftime("%Y-%m-%d %H:%M")
+    except (KeyError, ValueError):
+        return "unknown"
+
+
+def format_todo(todo: dict) -> str:
+    """Single-line summary: '[x] #1  Buy milk'"""
+    return f"[{_status_char(todo)}] #{todo['id']:<4} {todo['title']}"
+
+
+def format_todo_list(todos: list[dict]) -> str:
+    if not todos:
+        return "No todos found."
+    return "\n".join(format_todo(t) for t in todos)
+
+
+def format_todo_detail(todo: dict) -> str:
+    """Multi-line detail view for a single todo."""
+    lines = [
+        f"ID:      {todo['id']}",
+        f"Title:   {todo['title']}",
+        f"Status:  {'done' if todo['done'] else 'pending'}",
+        f"Created: {_created_label(todo)}",
+    ]
+    return "\n".join(lines)

--- a/formatter.py
+++ b/formatter.py
@@ -15,9 +15,14 @@ def _created_label(todo: dict) -> str:
         return "unknown"
 
 
+def _tags_label(todo: dict) -> str:
+    tags = todo.get("tags", [])
+    return f"  [{', '.join(tags)}]" if tags else ""
+
+
 def format_todo(todo: dict) -> str:
-    """Single-line summary: '[x] #1  Buy milk'"""
-    return f"[{_status_char(todo)}] #{todo['id']:<4} {todo['title']}"
+    """Single-line summary: '[x] #1  Buy milk  [tag1, tag2]'"""
+    return f"[{_status_char(todo)}] #{todo['id']:<4} {todo['title']}{_tags_label(todo)}"
 
 
 def format_todo_list(todos: list[dict]) -> str:
@@ -28,10 +33,12 @@ def format_todo_list(todos: list[dict]) -> str:
 
 def format_todo_detail(todo: dict) -> str:
     """Multi-line detail view for a single todo."""
+    tags = todo.get("tags", [])
     lines = [
         f"ID:      {todo['id']}",
         f"Title:   {todo['title']}",
         f"Status:  {'done' if todo['done'] else 'pending'}",
         f"Created: {_created_label(todo)}",
+        f"Tags:    {', '.join(tags) if tags else '(none)'}",
     ]
     return "\n".join(lines)

--- a/formatter.py
+++ b/formatter.py
@@ -31,6 +31,18 @@ def format_todo_list(todos: list[dict]) -> str:
     return "\n".join(format_todo(t) for t in todos)
 
 
+def format_todo_groups(groups: list[tuple[str, list[dict]]]) -> str:
+    """Format grouped todos with a section header per group."""
+    if not groups:
+        return "No todos found."
+    sections = []
+    for label, todos in groups:
+        header = f"=== {label} ==="
+        body = "\n".join(format_todo(t) for t in todos)
+        sections.append(f"{header}\n{body}")
+    return "\n\n".join(sections)
+
+
 def format_todo_detail(todo: dict) -> str:
     """Multi-line detail view for a single todo."""
     tags = todo.get("tags", [])

--- a/main.py
+++ b/main.py
@@ -12,16 +12,17 @@ import validator
 def cmd_add(args: argparse.Namespace) -> int:
     try:
         title = validator.validate_title(" ".join(args.title))
+        tags = validator.validate_tags(args.tags or "")
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    item = todo.add_todo(title)
+    item = todo.add_todo(title, tags=tags)
     print(f"Added: {formatter.format_todo(item)}")
     return 0
 
 
 def cmd_list(args: argparse.Namespace) -> int:
-    items = todo.list_todos(show_done=args.all)
+    items = todo.list_todos(show_done=args.all, tag=args.tag)
     print(formatter.format_todo_list(items))
     return 0
 
@@ -81,12 +82,20 @@ def build_parser() -> argparse.ArgumentParser:
     # add
     p_add = sub.add_parser("add", help="Add a new todo item.")
     p_add.add_argument("title", nargs="+", help="Title of the todo item.")
+    p_add.add_argument(
+        "--tags", metavar="TAGS",
+        help="Comma-separated tags (e.g. 'work,urgent').",
+    )
     p_add.set_defaults(func=cmd_add)
 
     # list
     p_list = sub.add_parser("list", help="List todo items.")
     p_list.add_argument(
         "--all", action="store_true", help="Include completed todos."
+    )
+    p_list.add_argument(
+        "--tag", metavar="TAG",
+        help="Filter to todos that have this tag.",
     )
     p_list.set_defaults(func=cmd_list)
 

--- a/main.py
+++ b/main.py
@@ -23,7 +23,13 @@ def cmd_add(args: argparse.Namespace) -> int:
 
 def cmd_list(args: argparse.Namespace) -> int:
     items = todo.list_todos(show_done=args.all, tag=args.tag)
-    print(formatter.format_todo_list(items))
+    if args.sort_by:
+        items = todo.sort_todos(items, args.sort_by)
+    if args.group_by:
+        groups = todo.group_todos(items, args.group_by)
+        print(formatter.format_todo_groups(groups))
+    else:
+        print(formatter.format_todo_list(items))
     return 0
 
 
@@ -102,6 +108,18 @@ def build_parser() -> argparse.ArgumentParser:
     p_list.add_argument(
         "--tag", metavar="TAG",
         help="Filter to todos that have this tag.",
+    )
+    p_list.add_argument(
+        "--sort-by",
+        choices=["priority", "due_date", "created_at", "title"],
+        metavar="FIELD",
+        help="Sort by field: priority, due_date, created_at, or title.",
+    )
+    p_list.add_argument(
+        "--group-by",
+        choices=["tag", "priority", "due_date"],
+        metavar="FIELD",
+        help="Group by field: tag, priority, or due_date. Prints section headers.",
     )
     p_list.set_defaults(func=cmd_list)
 

--- a/main.py
+++ b/main.py
@@ -57,6 +57,12 @@ def cmd_delete(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_search(args: argparse.Namespace) -> int:
+    items = todo.search_todos(args.query)
+    print(formatter.format_todo_list(items))
+    return 0
+
+
 def cmd_show(args: argparse.Namespace) -> int:
     try:
         todo_id = validator.validate_id(args.id)
@@ -113,6 +119,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_show = sub.add_parser("show", help="Show detail for a todo item.")
     p_show.add_argument("id", help="ID of the todo to show.")
     p_show.set_defaults(func=cmd_show)
+
+    # search
+    p_search = sub.add_parser("search", help="Search todos by title or tag.")
+    p_search.add_argument("query", help="Substring to search for (case-insensitive).")
+    p_search.set_defaults(func=cmd_search)
 
     return parser
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Todo CLI — entry point."""
+
+import argparse
+import sys
+
+import formatter
+import todo
+import validator
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    try:
+        title = validator.validate_title(" ".join(args.title))
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    item = todo.add_todo(title)
+    print(f"Added: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    items = todo.list_todos(show_done=args.all)
+    print(formatter.format_todo_list(items))
+    return 0
+
+
+def cmd_done(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    try:
+        item = todo.mark_done(todo_id)
+    except KeyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Marked done: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    try:
+        item = todo.delete_todo(todo_id)
+    except KeyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Deleted: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    item = todo.get_todo(todo_id)
+    if item is None:
+        print(f"Error: Todo #{todo_id} not found.", file=sys.stderr)
+        return 1
+    print(formatter.format_todo_detail(item))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="todo",
+        description="A simple command-line todo manager.",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="<command>")
+    sub.required = True
+
+    # add
+    p_add = sub.add_parser("add", help="Add a new todo item.")
+    p_add.add_argument("title", nargs="+", help="Title of the todo item.")
+    p_add.set_defaults(func=cmd_add)
+
+    # list
+    p_list = sub.add_parser("list", help="List todo items.")
+    p_list.add_argument(
+        "--all", action="store_true", help="Include completed todos."
+    )
+    p_list.set_defaults(func=cmd_list)
+
+    # done
+    p_done = sub.add_parser("done", help="Mark a todo as done.")
+    p_done.add_argument("id", help="ID of the todo to mark done.")
+    p_done.set_defaults(func=cmd_done)
+
+    # delete
+    p_del = sub.add_parser("delete", help="Delete a todo item.")
+    p_del.add_argument("id", help="ID of the todo to delete.")
+    p_del.set_defaults(func=cmd_delete)
+
+    # show
+    p_show = sub.add_parser("show", help="Show detail for a todo item.")
+    p_show.add_argument("id", help="ID of the todo to show.")
+    p_show.set_defaults(func=cmd_show)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def cmd_done(args: argparse.Namespace) -> int:
         return 1
     try:
         item = todo.mark_done(todo_id)
-    except KeyError as e:
+    except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"Marked done: {formatter.format_todo(item)}")
@@ -50,7 +50,7 @@ def cmd_delete(args: argparse.Namespace) -> int:
         return 1
     try:
         item = todo.delete_todo(todo_id)
-    except KeyError as e:
+    except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"Deleted: {formatter.format_todo(item)}")

--- a/test_sort_group.py
+++ b/test_sort_group.py
@@ -1,0 +1,226 @@
+"""Tests for --sort-by and --group-by on the list command (pb-30)."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import formatter
+import todo as todo_module
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        os.environ["TODO_FILE"] = str(Path(self._tmpdir.name) / "todos.json")
+
+    def tearDown(self):
+        os.environ.pop("TODO_FILE", None)
+        self._tmpdir.cleanup()
+
+    def _run_list(self, argv):
+        import main as main_mod
+        parser = main_mod.build_parser()
+        args = parser.parse_args(["list"] + argv)
+        return args.func(args)
+
+
+# ---------------------------------------------------------------------------
+# sort_todos
+# ---------------------------------------------------------------------------
+
+class TestSortByTitle(Base):
+    def test_sorts_ascending(self):
+        todo_module.add_todo("Zebra")
+        todo_module.add_todo("Apple")
+        todo_module.add_todo("Mango")
+        items = todo_module.list_todos()
+        result = todo_module.sort_todos(items, "title")
+        self.assertEqual([t["title"] for t in result], ["Apple", "Mango", "Zebra"])
+
+    def test_case_insensitive(self):
+        todo_module.add_todo("banana")
+        todo_module.add_todo("Apple")
+        items = todo_module.list_todos()
+        result = todo_module.sort_todos(items, "title")
+        self.assertEqual(result[0]["title"], "Apple")
+
+    def test_stable_for_equal_keys(self):
+        todo_module.add_todo("Same")
+        todo_module.add_todo("Same")
+        items = todo_module.list_todos()
+        result = todo_module.sort_todos(items, "title")
+        self.assertEqual([t["id"] for t in result], [1, 2])
+
+
+class TestSortByCreatedAt(Base):
+    def test_sorts_chronologically(self):
+        todo_module.add_todo("First")
+        todo_module.add_todo("Second")
+        todo_module.add_todo("Third")
+        items = todo_module.list_todos()
+        result = todo_module.sort_todos(items, "created_at")
+        self.assertEqual([t["title"] for t in result], ["First", "Second", "Third"])
+
+    def test_missing_created_at_sorts_last(self):
+        todo_module.add_todo("Normal")
+        items = todo_module.list_todos()
+        items.append({"id": 99, "title": "No date", "done": False, "tags": []})
+        result = todo_module.sort_todos(items, "created_at")
+        self.assertEqual(result[-1]["title"], "No date")
+
+
+class TestSortByOptionalField(Base):
+    def test_missing_priority_sorts_last(self):
+        todo_module.add_todo("No priority")
+        items = todo_module.list_todos()
+        items[0]["priority"] = None
+        extra = {"id": 2, "title": "Has priority", "done": False,
+                 "tags": [], "priority": "high"}
+        result = todo_module.sort_todos([items[0], extra], "priority")
+        self.assertEqual(result[0]["title"], "Has priority")
+
+    def test_missing_due_date_sorts_last(self):
+        has_date = {"id": 1, "title": "Due soon", "done": False,
+                    "tags": [], "due_date": "2026-01-01"}
+        no_date = {"id": 2, "title": "No date", "done": False, "tags": []}
+        result = todo_module.sort_todos([no_date, has_date], "due_date")
+        self.assertEqual(result[0]["title"], "Due soon")
+        self.assertEqual(result[1]["title"], "No date")
+
+
+# ---------------------------------------------------------------------------
+# group_todos
+# ---------------------------------------------------------------------------
+
+class TestGroupByTag(Base):
+    def test_groups_by_each_tag(self):
+        todo_module.add_todo("Work task", tags=["work"])
+        todo_module.add_todo("Home task", tags=["home"])
+        items = todo_module.list_todos()
+        groups = dict(todo_module.group_todos(items, "tag"))
+        self.assertIn("work", groups)
+        self.assertIn("home", groups)
+        self.assertEqual(groups["work"][0]["title"], "Work task")
+
+    def test_multi_tag_todo_appears_in_each_group(self):
+        todo_module.add_todo("Both", tags=["work", "urgent"])
+        items = todo_module.list_todos()
+        groups = dict(todo_module.group_todos(items, "tag"))
+        self.assertIn("work", groups)
+        self.assertIn("urgent", groups)
+        self.assertEqual(len(groups["work"]), 1)
+        self.assertEqual(len(groups["urgent"]), 1)
+
+    def test_untagged_goes_to_no_tag(self):
+        todo_module.add_todo("Untagged")
+        items = todo_module.list_todos()
+        groups = dict(todo_module.group_todos(items, "tag"))
+        self.assertIn("(no tag)", groups)
+
+    def test_groups_sorted_alphabetically(self):
+        todo_module.add_todo("Z task", tags=["zebra"])
+        todo_module.add_todo("A task", tags=["apple"])
+        items = todo_module.list_todos()
+        labels = [label for label, _ in todo_module.group_todos(items, "tag")]
+        self.assertEqual(labels, sorted(labels))
+
+    def test_empty_list_returns_no_groups(self):
+        groups = todo_module.group_todos([], "tag")
+        self.assertEqual(groups, [])
+
+
+class TestGroupByOptionalField(Base):
+    def test_group_by_priority(self):
+        high = {"id": 1, "title": "High", "done": False, "tags": [], "priority": "high"}
+        low = {"id": 2, "title": "Low", "done": False, "tags": [], "priority": "low"}
+        groups = dict(todo_module.group_todos([high, low], "priority"))
+        self.assertIn("high", groups)
+        self.assertIn("low", groups)
+
+    def test_missing_priority_goes_to_none(self):
+        todo_module.add_todo("No priority")
+        items = todo_module.list_todos()
+        groups = dict(todo_module.group_todos(items, "priority"))
+        self.assertIn("(none)", groups)
+
+    def test_group_by_due_date(self):
+        a = {"id": 1, "title": "A", "done": False, "tags": [], "due_date": "2026-06-01"}
+        b = {"id": 2, "title": "B", "done": False, "tags": []}
+        groups = dict(todo_module.group_todos([a, b], "due_date"))
+        self.assertIn("2026-06-01", groups)
+        self.assertIn("(none)", groups)
+
+
+# ---------------------------------------------------------------------------
+# format_todo_groups
+# ---------------------------------------------------------------------------
+
+class TestFormatTodoGroups(Base):
+    def test_empty_returns_no_todos(self):
+        self.assertEqual(formatter.format_todo_groups([]), "No todos found.")
+
+    def test_header_per_group(self):
+        groups = [
+            ("work", [{"id": 1, "title": "Task", "done": False, "tags": []}]),
+            ("home", [{"id": 2, "title": "Chore", "done": False, "tags": []}]),
+        ]
+        output = formatter.format_todo_groups(groups)
+        self.assertIn("=== work ===", output)
+        self.assertIn("=== home ===", output)
+        self.assertIn("Task", output)
+        self.assertIn("Chore", output)
+
+    def test_groups_separated_by_blank_line(self):
+        groups = [
+            ("a", [{"id": 1, "title": "T1", "done": False, "tags": []}]),
+            ("b", [{"id": 2, "title": "T2", "done": False, "tags": []}]),
+        ]
+        output = formatter.format_todo_groups(groups)
+        self.assertIn("\n\n", output)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+class TestListCLI(Base):
+    def test_sort_by_title_flag(self):
+        todo_module.add_todo("Zebra")
+        todo_module.add_todo("Apple")
+        # just verify it runs without error
+        result = self._run_list(["--sort-by", "title"])
+        self.assertEqual(result, 0)
+
+    def test_group_by_tag_flag(self):
+        todo_module.add_todo("Task", tags=["work"])
+        result = self._run_list(["--group-by", "tag"])
+        self.assertEqual(result, 0)
+
+    def test_sort_and_group_combined(self):
+        todo_module.add_todo("Zebra", tags=["work"])
+        todo_module.add_todo("Apple", tags=["work"])
+        result = self._run_list(["--sort-by", "title", "--group-by", "tag"])
+        self.assertEqual(result, 0)
+
+    def test_no_flags_unchanged(self):
+        todo_module.add_todo("Task")
+        result = self._run_list([])
+        self.assertEqual(result, 0)
+
+    def test_invalid_sort_by_rejected(self):
+        parser = __import__("main").build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["list", "--sort-by", "invalid"])
+
+    def test_invalid_group_by_rejected(self):
+        parser = __import__("main").build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["list", "--group-by", "invalid"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,74 @@
+"""Core todo CRUD operations backed by a JSON file."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from config import get_storage_path
+
+
+def _load_raw() -> dict:
+    path = get_storage_path()
+    if not path.exists():
+        return {"next_id": 1, "todos": []}
+    with path.open() as f:
+        return json.load(f)
+
+
+def _save_raw(data: dict) -> None:
+    path = get_storage_path()
+    with path.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_todos() -> list[dict]:
+    return _load_raw()["todos"]
+
+
+def add_todo(title: str) -> dict:
+    data = _load_raw()
+    todo = {
+        "id": data["next_id"],
+        "title": title,
+        "done": False,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    data["todos"].append(todo)
+    data["next_id"] += 1
+    _save_raw(data)
+    return todo
+
+
+def get_todo(todo_id: int) -> Optional[dict]:
+    for todo in load_todos():
+        if todo["id"] == todo_id:
+            return todo
+    return None
+
+
+def list_todos(show_done: bool = False) -> list[dict]:
+    todos = load_todos()
+    if not show_done:
+        todos = [t for t in todos if not t["done"]]
+    return todos
+
+
+def mark_done(todo_id: int) -> dict:
+    data = _load_raw()
+    for todo in data["todos"]:
+        if todo["id"] == todo_id:
+            todo["done"] = True
+            _save_raw(data)
+            return todo
+    raise KeyError(f"Todo #{todo_id} not found.")
+
+
+def delete_todo(todo_id: int) -> dict:
+    data = _load_raw()
+    for i, todo in enumerate(data["todos"]):
+        if todo["id"] == todo_id:
+            removed = data["todos"].pop(i)
+            _save_raw(data)
+            return removed
+    raise KeyError(f"Todo #{todo_id} not found.")

--- a/todo.py
+++ b/todo.py
@@ -57,6 +57,18 @@ def list_todos(show_done: bool = False, tag: Optional[str] = None) -> list[dict]
     return todos
 
 
+def search_todos(query: str) -> list[dict]:
+    q = query.lower()
+    results = []
+    for todo in load_todos():
+        if q in todo["title"].lower():
+            results.append(todo)
+            continue
+        if any(q in tag.lower() for tag in todo.get("tags", [])):
+            results.append(todo)
+    return results
+
+
 def mark_done(todo_id: int) -> dict:
     data = _load_raw()
     for todo in data["todos"]:

--- a/todo.py
+++ b/todo.py
@@ -57,6 +57,45 @@ def list_todos(show_done: bool = False, tag: Optional[str] = None) -> list[dict]
     return todos
 
 
+_SORT_SENTINEL = "\xff"  # sorts after all printable strings
+
+
+def sort_todos(todos: list[dict], sort_by: str) -> list[dict]:
+    """Return a new list sorted by *sort_by* field. Missing values sort last."""
+    if sort_by == "title":
+        key = lambda t: t.get("title", "").lower()
+    elif sort_by == "created_at":
+        key = lambda t: t.get("created_at") or _SORT_SENTINEL
+    else:
+        key = lambda t: t.get(sort_by) or _SORT_SENTINEL
+    return sorted(todos, key=key)
+
+
+def group_todos(todos: list[dict], group_by: str) -> list[tuple[str, list[dict]]]:
+    """Return [(label, [todos])] groups, sorted by label. Missing values → '(none)'.
+
+    For group_by='tag' each todo appears under every tag it carries; untagged
+    todos appear under '(no tag)'.
+    """
+    buckets: dict[str, list[dict]] = {}
+
+    if group_by == "tag":
+        for t in todos:
+            tags = t.get("tags", [])
+            if not tags:
+                buckets.setdefault("(no tag)", []).append(t)
+            else:
+                for tag in tags:
+                    buckets.setdefault(tag, []).append(t)
+    else:
+        for t in todos:
+            val = t.get(group_by)
+            label = str(val) if val is not None else "(none)"
+            buckets.setdefault(label, []).append(t)
+
+    return sorted(buckets.items(), key=lambda kv: kv[0])
+
+
 def search_todos(query: str) -> list[dict]:
     q = query.lower()
     results = []

--- a/todo.py
+++ b/todo.py
@@ -26,13 +26,14 @@ def load_todos() -> list[dict]:
     return _load_raw()["todos"]
 
 
-def add_todo(title: str) -> dict:
+def add_todo(title: str, tags: Optional[list[str]] = None) -> dict:
     data = _load_raw()
     todo = {
         "id": data["next_id"],
         "title": title,
         "done": False,
         "created_at": datetime.now(timezone.utc).isoformat(),
+        "tags": tags or [],
     }
     data["todos"].append(todo)
     data["next_id"] += 1
@@ -47,10 +48,12 @@ def get_todo(todo_id: int) -> Optional[dict]:
     return None
 
 
-def list_todos(show_done: bool = False) -> list[dict]:
+def list_todos(show_done: bool = False, tag: Optional[str] = None) -> list[dict]:
     todos = load_todos()
     if not show_done:
         todos = [t for t in todos if not t["done"]]
+    if tag:
+        todos = [t for t in todos if tag in t.get("tags", [])]
     return todos
 
 

--- a/todo.py
+++ b/todo.py
@@ -76,7 +76,7 @@ def mark_done(todo_id: int) -> dict:
             todo["done"] = True
             _save_raw(data)
             return todo
-    raise KeyError(f"Todo #{todo_id} not found.")
+    raise ValueError(f"Todo #{todo_id} not found.")
 
 
 def delete_todo(todo_id: int) -> dict:
@@ -86,4 +86,4 @@ def delete_todo(todo_id: int) -> dict:
             removed = data["todos"].pop(i)
             _save_raw(data)
             return removed
-    raise KeyError(f"Todo #{todo_id} not found.")
+    raise ValueError(f"Todo #{todo_id} not found.")

--- a/validator.py
+++ b/validator.py
@@ -1,0 +1,20 @@
+"""Input validation for the todo CLI."""
+
+
+def validate_title(title: str) -> str:
+    """Return stripped title, raising ValueError if blank."""
+    stripped = title.strip()
+    if not stripped:
+        raise ValueError("Todo title cannot be empty.")
+    return stripped
+
+
+def validate_id(raw_id: str) -> int:
+    """Return integer id, raising ValueError if not a positive integer."""
+    try:
+        todo_id = int(raw_id)
+    except (TypeError, ValueError):
+        raise ValueError(f"Invalid id '{raw_id}': must be a positive integer.")
+    if todo_id < 1:
+        raise ValueError(f"Invalid id '{raw_id}': must be a positive integer.")
+    return todo_id

--- a/validator.py
+++ b/validator.py
@@ -9,6 +9,14 @@ def validate_title(title: str) -> str:
     return stripped
 
 
+def validate_tags(raw_tags: str) -> list[str]:
+    """Parse comma-separated tags, stripping whitespace. Returns empty list for blank input."""
+    if not raw_tags or not raw_tags.strip():
+        return []
+    tags = [t.strip() for t in raw_tags.split(",")]
+    return [t for t in tags if t]
+
+
 def validate_id(raw_id: str) -> int:
     """Return integer id, raising ValueError if not a positive integer."""
     try:


### PR DESCRIPTION
## Summary

Add --sort-by (priority, due_date, created_at, title) and --group-by (tag, priority, due_date) flags to the list subcommand. Group-by prints section headers between groups.


Ticket: pb-30