### PR TITLE
[pb-31] Batch operations for multiple todos

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,24 @@
+"""Configuration and storage path management for the todo CLI."""
+
+import os
+from pathlib import Path
+
+
+def get_storage_path() -> Path:
+    """Return path to the todos JSON file, respecting TODO_FILE env override."""
+    env_path = os.environ.get("TODO_FILE")
+    if env_path:
+        return Path(env_path)
+    data_dir = Path.home() / ".local" / "share" / "todo-cli"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir / "todos.json"
+
+
+def get_archive_path() -> Path:
+    """Return path to the archive JSON file, respecting TODO_ARCHIVE_FILE env override."""
+    env_path = os.environ.get("TODO_ARCHIVE_FILE")
+    if env_path:
+        return Path(env_path)
+    data_dir = Path.home() / ".local" / "share" / "todo-cli"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir / "archive.json"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/formatter.py
+++ b/formatter.py
@@ -1,0 +1,52 @@
+"""Terminal output formatting for todo items."""
+
+from datetime import datetime, timezone
+
+
+def _status_char(todo: dict) -> str:
+    return "x" if todo["done"] else " "
+
+
+def _created_label(todo: dict) -> str:
+    try:
+        dt = datetime.fromisoformat(todo["created_at"])
+        return dt.astimezone().strftime("%Y-%m-%d %H:%M")
+    except (KeyError, ValueError):
+        return "unknown"
+
+
+def _tags_label(todo: dict) -> str:
+    tags = todo.get("tags", [])
+    return f"  [{', '.join(tags)}]" if tags else ""
+
+
+def format_todo(todo: dict) -> str:
+    """Single-line summary: '[x] #1  Buy milk  [tag1, tag2]'"""
+    if todo.get("archived"):
+        return f"[archived] #{todo['id']:<4} {todo['title']}{_tags_label(todo)}"
+    return f"[{_status_char(todo)}] #{todo['id']:<4} {todo['title']}{_tags_label(todo)}"
+
+
+def format_todo_list(todos: list[dict]) -> str:
+    if not todos:
+        return "No todos found."
+    return "\n".join(format_todo(t) for t in todos)
+
+
+def format_todo_detail(todo: dict) -> str:
+    """Multi-line detail view for a single todo."""
+    tags = todo.get("tags", [])
+    if todo.get("archived"):
+        status = "archived"
+    elif todo["done"]:
+        status = "done"
+    else:
+        status = "pending"
+    lines = [
+        f"ID:      {todo['id']}",
+        f"Title:   {todo['title']}",
+        f"Status:  {status}",
+        f"Created: {_created_label(todo)}",
+        f"Tags:    {', '.join(tags) if tags else '(none)'}",
+    ]
+    return "\n".join(lines)

--- a/formatter.py
+++ b/formatter.py
@@ -1,6 +1,6 @@
 """Terminal output formatting for todo items."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 
 
 def _status_char(todo: dict) -> str:

--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ def cmd_done(args: argparse.Namespace) -> int:
         return 1
     try:
         item = todo.mark_done(todo_id)
-    except KeyError as e:
+    except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"Marked done: {formatter.format_todo(item)}")
@@ -135,7 +135,7 @@ def cmd_delete(args: argparse.Namespace) -> int:
         return 1
     try:
         item = todo.delete_todo(todo_id)
-    except KeyError as e:
+    except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     print(f"Deleted: {formatter.format_todo(item)}")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Todo CLI — entry point."""
+
+import argparse
+import sys
+
+import formatter
+import todo
+import validator
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    try:
+        title = validator.validate_title(" ".join(args.title))
+        tags = validator.validate_tags(args.tags or "")
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    item = todo.add_todo(title, tags=tags)
+    print(f"Added: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_archive(args: argparse.Namespace) -> int:
+    count = todo.archive_done()
+    if count == 0:
+        print("No completed todos to archive.")
+    else:
+        print(f"Archived {count} completed todo{'s' if count != 1 else ''}.")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    items = todo.list_todos(
+        show_done=args.all,
+        tag=args.tag,
+        include_archived=args.include_archived,
+    )
+    print(formatter.format_todo_list(items))
+    return 0
+
+
+def _pluralise(count: int, noun: str = "todo") -> str:
+    return f"{count} {noun}{'s' if count != 1 else ''}"
+
+
+def cmd_done(args: argparse.Namespace) -> int:
+    n_modes = sum([bool(args.id), bool(getattr(args, "ids", None)), args.all_overdue])
+    if n_modes == 0:
+        print("Error: specify an ID, --ids IDs..., or --all-overdue.", file=sys.stderr)
+        return 1
+    if n_modes > 1:
+        print("Error: ID, --ids, and --all-overdue are mutually exclusive.", file=sys.stderr)
+        return 1
+
+    if args.all_overdue:
+        completed = todo.mark_done_overdue()
+        if not completed:
+            print("No overdue todos found.")
+        else:
+            for item in completed:
+                print(f"Marked done: {formatter.format_todo(item)}")
+            print(f"{_pluralise(len(completed))} marked done.")
+        return 0
+
+    if args.ids:
+        try:
+            ids = [validator.validate_id(i) for i in args.ids]
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        completed, missing = todo.mark_done_batch(ids)
+        for item in completed:
+            print(f"Marked done: {formatter.format_todo(item)}")
+        for mid in missing:
+            print(f"Error: Todo #{mid} not found.", file=sys.stderr)
+        if completed:
+            print(f"{_pluralise(len(completed))} marked done.")
+        return 1 if missing else 0
+
+    # Single ID
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    try:
+        item = todo.mark_done(todo_id)
+    except KeyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Marked done: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    n_modes = sum([bool(args.id), bool(getattr(args, "ids", None)), args.delete_done])
+    if n_modes == 0:
+        print("Error: specify an ID, --ids IDs..., or --done.", file=sys.stderr)
+        return 1
+    if n_modes > 1:
+        print("Error: ID, --ids, and --done are mutually exclusive.", file=sys.stderr)
+        return 1
+
+    if args.delete_done:
+        deleted = todo.delete_completed()
+        if not deleted:
+            print("No completed todos to delete.")
+        else:
+            for item in deleted:
+                print(f"Deleted: {formatter.format_todo(item)}")
+            print(f"{_pluralise(len(deleted))} deleted.")
+        return 0
+
+    if args.ids:
+        try:
+            ids = [validator.validate_id(i) for i in args.ids]
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        deleted, missing = todo.delete_batch(ids)
+        for item in deleted:
+            print(f"Deleted: {formatter.format_todo(item)}")
+        for mid in missing:
+            print(f"Error: Todo #{mid} not found.", file=sys.stderr)
+        if deleted:
+            print(f"{_pluralise(len(deleted))} deleted.")
+        return 1 if missing else 0
+
+    # Single ID
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    try:
+        item = todo.delete_todo(todo_id)
+    except KeyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Deleted: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    items = todo.search_todos(args.query, include_archived=args.include_archived)
+    print(formatter.format_todo_list(items))
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    item = todo.get_todo(todo_id)
+    if item is None:
+        print(f"Error: Todo #{todo_id} not found.", file=sys.stderr)
+        return 1
+    print(formatter.format_todo_detail(item))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="todo",
+        description="A simple command-line todo manager.",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="<command>")
+    sub.required = True
+
+    # add
+    p_add = sub.add_parser("add", help="Add a new todo item.")
+    p_add.add_argument("title", nargs="+", help="Title of the todo item.")
+    p_add.add_argument(
+        "--tags", metavar="TAGS",
+        help="Comma-separated tags (e.g. 'work,urgent').",
+    )
+    p_add.set_defaults(func=cmd_add)
+
+    # list
+    p_list = sub.add_parser("list", help="List todo items.")
+    p_list.add_argument(
+        "--all", action="store_true", help="Include completed todos."
+    )
+    p_list.add_argument(
+        "--tag", metavar="TAG",
+        help="Filter to todos that have this tag.",
+    )
+    p_list.add_argument(
+        "--include-archived", action="store_true",
+        help="Include archived todos in the output.",
+    )
+    p_list.set_defaults(func=cmd_list)
+
+    # done
+    p_done = sub.add_parser("done", help="Mark one or more todos as done.")
+    p_done.add_argument(
+        "id", nargs="?", default=None,
+        help="ID of a single todo to mark done.",
+    )
+    p_done.add_argument(
+        "--ids", nargs="+", metavar="ID",
+        help="IDs of multiple todos to mark done.",
+    )
+    p_done.add_argument(
+        "--all-overdue", action="store_true", dest="all_overdue",
+        help="Mark all overdue todos (past due_date) as done.",
+    )
+    p_done.set_defaults(func=cmd_done)
+
+    # delete
+    p_del = sub.add_parser("delete", help="Delete one or more todos.")
+    p_del.add_argument(
+        "id", nargs="?", default=None,
+        help="ID of a single todo to delete.",
+    )
+    p_del.add_argument(
+        "--ids", nargs="+", metavar="ID",
+        help="IDs of multiple todos to delete.",
+    )
+    p_del.add_argument(
+        "--done", action="store_true", dest="delete_done",
+        help="Delete all completed todos.",
+    )
+    p_del.set_defaults(func=cmd_delete)
+
+    # show
+    p_show = sub.add_parser("show", help="Show detail for a todo item.")
+    p_show.add_argument("id", help="ID of the todo to show.")
+    p_show.set_defaults(func=cmd_show)
+
+    # search
+    p_search = sub.add_parser("search", help="Search todos by title or tag.")
+    p_search.add_argument("query", help="Substring to search for (case-insensitive).")
+    p_search.add_argument(
+        "--include-archived", action="store_true",
+        help="Include archived todos in search results.",
+    )
+    p_search.set_defaults(func=cmd_search)
+
+    # archive
+    p_archive = sub.add_parser("archive", help="Move completed todos to the archive.")
+    p_archive.set_defaults(func=cmd_archive)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_batch.py
+++ b/test_batch.py
@@ -1,0 +1,246 @@
+"""Tests for batch todo operations: mark_done_batch, mark_done_overdue,
+delete_batch, delete_completed."""
+
+import pytest
+
+import todo
+
+
+@pytest.fixture(autouse=True)
+def isolate_storage(tmp_path, monkeypatch):
+    monkeypatch.setenv("TODO_FILE", str(tmp_path / "todos.json"))
+
+
+def _seed(*titles) -> list[dict]:
+    return [todo.add_todo(t) for t in titles]
+
+
+# ---------------------------------------------------------------------------
+# mark_done_batch
+# ---------------------------------------------------------------------------
+
+class TestMarkDoneBatch:
+    def test_all_found_returns_all_completed(self):
+        items = _seed("A", "B", "C")
+        ids = [t["id"] for t in items]
+        completed, missing = todo.mark_done_batch(ids)
+        assert len(completed) == 3
+        assert missing == []
+
+    def test_all_found_sets_done_true(self):
+        items = _seed("A", "B")
+        ids = [t["id"] for t in items]
+        todo.mark_done_batch(ids)
+        for t in items:
+            assert todo.get_todo(t["id"])["done"] is True
+
+    def test_all_found_single_write_persists(self):
+        items = _seed("A", "B")
+        ids = [t["id"] for t in items]
+        todo.mark_done_batch(ids)
+        assert all(todo.get_todo(i["id"])["done"] for i in items)
+
+    def test_partial_missing_returns_found_and_missing(self):
+        items = _seed("A", "B")
+        completed, missing = todo.mark_done_batch([items[0]["id"], 9999])
+        assert len(completed) == 1
+        assert completed[0]["id"] == items[0]["id"]
+        assert missing == [9999]
+
+    def test_partial_missing_marks_found_ones_done(self):
+        items = _seed("A", "B")
+        todo.mark_done_batch([items[0]["id"], 9999])
+        assert todo.get_todo(items[0]["id"])["done"] is True
+        assert todo.get_todo(items[1]["id"])["done"] is False
+
+    def test_all_missing_returns_empty_completed(self):
+        _seed("A")
+        completed, missing = todo.mark_done_batch([9998, 9999])
+        assert completed == []
+        assert missing == [9998, 9999]
+
+    def test_all_missing_does_not_write(self, tmp_path, monkeypatch):
+        path = tmp_path / "todos.json"
+        monkeypatch.setenv("TODO_FILE", str(path))
+        todo.add_todo("A")
+        mtime_before = path.stat().st_mtime
+        todo.mark_done_batch([9999])
+        assert path.stat().st_mtime == mtime_before
+
+    def test_missing_ids_sorted(self):
+        _seed("A")
+        _, missing = todo.mark_done_batch([30, 10, 20])
+        assert missing == [10, 20, 30]
+
+    def test_empty_ids_list(self):
+        _seed("A")
+        completed, missing = todo.mark_done_batch([])
+        assert completed == []
+        assert missing == []
+
+
+# ---------------------------------------------------------------------------
+# mark_done_overdue
+# ---------------------------------------------------------------------------
+
+class TestMarkDoneOverdue:
+    def test_past_due_date_marked_done(self):
+        t = todo.add_todo("Overdue")
+        # inject a past due_date directly
+        import json, os
+        path = os.environ["TODO_FILE"]
+        data = json.loads(open(path).read())
+        for item in data["todos"]:
+            if item["id"] == t["id"]:
+                item["due_date"] = "2000-01-01"
+        open(path, "w").write(json.dumps(data))
+
+        result = todo.mark_done_overdue()
+        assert len(result) == 1
+        assert result[0]["id"] == t["id"]
+        assert todo.get_todo(t["id"])["done"] is True
+
+    def test_future_due_date_not_marked(self):
+        t = todo.add_todo("Future")
+        import json, os
+        path = os.environ["TODO_FILE"]
+        data = json.loads(open(path).read())
+        for item in data["todos"]:
+            if item["id"] == t["id"]:
+                item["due_date"] = "2099-12-31"
+        open(path, "w").write(json.dumps(data))
+
+        result = todo.mark_done_overdue()
+        assert result == []
+        assert todo.get_todo(t["id"])["done"] is False
+
+    def test_no_due_date_not_marked(self):
+        todo.add_todo("No due date")
+        result = todo.mark_done_overdue()
+        assert result == []
+
+    def test_already_done_skipped(self):
+        t = todo.add_todo("Already done")
+        todo.mark_done(t["id"])
+        import json, os
+        path = os.environ["TODO_FILE"]
+        data = json.loads(open(path).read())
+        for item in data["todos"]:
+            if item["id"] == t["id"]:
+                item["due_date"] = "2000-01-01"
+        open(path, "w").write(json.dumps(data))
+
+        result = todo.mark_done_overdue()
+        assert result == []
+
+    def test_mixed_returns_only_overdue(self):
+        t_over = todo.add_todo("Overdue")
+        t_future = todo.add_todo("Future")
+        import json, os
+        path = os.environ["TODO_FILE"]
+        data = json.loads(open(path).read())
+        for item in data["todos"]:
+            if item["id"] == t_over["id"]:
+                item["due_date"] = "2000-01-01"
+            elif item["id"] == t_future["id"]:
+                item["due_date"] = "2099-12-31"
+        open(path, "w").write(json.dumps(data))
+
+        result = todo.mark_done_overdue()
+        assert len(result) == 1
+        assert result[0]["id"] == t_over["id"]
+
+    def test_empty_store_returns_empty(self):
+        assert todo.mark_done_overdue() == []
+
+
+# ---------------------------------------------------------------------------
+# delete_batch
+# ---------------------------------------------------------------------------
+
+class TestDeleteBatch:
+    def test_all_found_deletes_all(self):
+        items = _seed("A", "B", "C")
+        ids = [t["id"] for t in items]
+        deleted, missing = todo.delete_batch(ids)
+        assert len(deleted) == 3
+        assert missing == []
+        assert todo.list_todos(show_done=True) == []
+
+    def test_partial_missing_deletes_found(self):
+        items = _seed("A", "B")
+        deleted, missing = todo.delete_batch([items[0]["id"], 9999])
+        assert len(deleted) == 1
+        assert deleted[0]["id"] == items[0]["id"]
+        assert missing == [9999]
+        assert todo.get_todo(items[1]["id"]) is not None
+
+    def test_all_missing_returns_empty_deleted(self):
+        _seed("A")
+        deleted, missing = todo.delete_batch([9998, 9999])
+        assert deleted == []
+        assert missing == [9998, 9999]
+
+    def test_all_missing_does_not_write(self, tmp_path, monkeypatch):
+        path = tmp_path / "todos2.json"
+        monkeypatch.setenv("TODO_FILE", str(path))
+        todo.add_todo("A")
+        mtime_before = path.stat().st_mtime
+        todo.delete_batch([9999])
+        assert path.stat().st_mtime == mtime_before
+
+    def test_missing_ids_sorted(self):
+        _seed("A")
+        _, missing = todo.delete_batch([30, 10, 20])
+        assert missing == [10, 20, 30]
+
+    def test_empty_ids_list(self):
+        _seed("A")
+        deleted, missing = todo.delete_batch([])
+        assert deleted == []
+        assert missing == []
+
+
+# ---------------------------------------------------------------------------
+# delete_completed
+# ---------------------------------------------------------------------------
+
+class TestDeleteCompleted:
+    def test_deletes_all_completed(self):
+        items = _seed("A", "B", "C")
+        for t in items:
+            todo.mark_done(t["id"])
+        deleted = todo.delete_completed()
+        assert len(deleted) == 3
+        assert todo.list_todos(show_done=True) == []
+
+    def test_leaves_pending_intact(self):
+        keep = todo.add_todo("Keep")
+        remove = todo.add_todo("Remove")
+        todo.mark_done(remove["id"])
+        todo.delete_completed()
+        assert todo.get_todo(keep["id"]) is not None
+        assert todo.get_todo(remove["id"]) is None
+
+    def test_no_completed_returns_empty(self):
+        _seed("A", "B")
+        result = todo.delete_completed()
+        assert result == []
+
+    def test_no_completed_does_not_write(self, tmp_path, monkeypatch):
+        path = tmp_path / "todos3.json"
+        monkeypatch.setenv("TODO_FILE", str(path))
+        todo.add_todo("Pending")
+        mtime_before = path.stat().st_mtime
+        todo.delete_completed()
+        assert path.stat().st_mtime == mtime_before
+
+    def test_empty_store_returns_empty(self):
+        assert todo.delete_completed() == []
+
+    def test_returns_deleted_items(self):
+        t = todo.add_todo("Remove me")
+        todo.mark_done(t["id"])
+        deleted = todo.delete_completed()
+        assert len(deleted) == 1
+        assert deleted[0]["title"] == "Remove me"

--- a/todo.py
+++ b/todo.py
@@ -122,7 +122,7 @@ def mark_done(todo_id: int) -> dict:
             todo["done"] = True
             _save_raw(data)
             return todo
-    raise KeyError(f"Todo #{todo_id} not found.")
+    raise ValueError(f"Todo #{todo_id} not found.")
 
 
 def mark_done_batch(ids: list[int]) -> tuple[list[dict], list[int]]:
@@ -178,7 +178,7 @@ def delete_todo(todo_id: int) -> dict:
             removed = data["todos"].pop(i)
             _save_raw(data)
             return removed
-    raise KeyError(f"Todo #{todo_id} not found.")
+    raise ValueError(f"Todo #{todo_id} not found.")
 
 
 def delete_batch(ids: list[int]) -> tuple[list[dict], list[int]]:

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,212 @@
+"""Core todo CRUD operations backed by a JSON file."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from config import get_archive_path, get_storage_path
+
+
+def _load_raw() -> dict:
+    path = get_storage_path()
+    if not path.exists():
+        return {"next_id": 1, "todos": []}
+    with path.open() as f:
+        return json.load(f)
+
+
+def _save_raw(data: dict) -> None:
+    path = get_storage_path()
+    with path.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _load_archive() -> dict:
+    path = get_archive_path()
+    if not path.exists():
+        return {"todos": []}
+    with path.open() as f:
+        return json.load(f)
+
+
+def _save_archive(data: dict) -> None:
+    path = get_archive_path()
+    with path.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_todos() -> list[dict]:
+    return _load_raw()["todos"]
+
+
+def add_todo(title: str, tags: Optional[list[str]] = None) -> dict:
+    data = _load_raw()
+    todo = {
+        "id": data["next_id"],
+        "title": title,
+        "done": False,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "tags": tags or [],
+    }
+    data["todos"].append(todo)
+    data["next_id"] += 1
+    _save_raw(data)
+    return todo
+
+
+def get_todo(todo_id: int) -> Optional[dict]:
+    for todo in load_todos():
+        if todo["id"] == todo_id:
+            return todo
+    return None
+
+
+def load_archived() -> list[dict]:
+    return _load_archive()["todos"]
+
+
+def archive_done() -> int:
+    """Move all done todos from the active store to the archive. Returns count moved."""
+    data = _load_raw()
+    done = [t for t in data["todos"] if t["done"]]
+    if not done:
+        return 0
+    for t in done:
+        t["archived"] = True
+    archive = _load_archive()
+    archive["todos"].extend(done)
+    _save_archive(archive)
+    data["todos"] = [t for t in data["todos"] if not t["done"]]
+    _save_raw(data)
+    return len(done)
+
+
+def list_todos(
+    show_done: bool = False,
+    tag: Optional[str] = None,
+    include_archived: bool = False,
+) -> list[dict]:
+    todos = load_todos()
+    if not show_done:
+        todos = [t for t in todos if not t["done"]]
+    if tag:
+        todos = [t for t in todos if tag in t.get("tags", [])]
+    if include_archived:
+        archived = load_archived()
+        if tag:
+            archived = [t for t in archived if tag in t.get("tags", [])]
+        todos = todos + archived
+    return todos
+
+
+def search_todos(query: str, include_archived: bool = False) -> list[dict]:
+    q = query.lower()
+    sources = load_todos()
+    if include_archived:
+        sources = sources + load_archived()
+    results = []
+    for todo in sources:
+        if q in todo["title"].lower():
+            results.append(todo)
+            continue
+        if any(q in tag.lower() for tag in todo.get("tags", [])):
+            results.append(todo)
+    return results
+
+
+def mark_done(todo_id: int) -> dict:
+    data = _load_raw()
+    for todo in data["todos"]:
+        if todo["id"] == todo_id:
+            todo["done"] = True
+            _save_raw(data)
+            return todo
+    raise KeyError(f"Todo #{todo_id} not found.")
+
+
+def mark_done_batch(ids: list[int]) -> tuple[list[dict], list[int]]:
+    """Mark multiple todos done in a single write.
+
+    Returns (completed, missing_ids) where missing_ids are IDs not found.
+    """
+    data = _load_raw()
+    remaining = set(ids)
+    completed = []
+    for todo in data["todos"]:
+        if todo["id"] in remaining:
+            todo["done"] = True
+            completed.append(todo)
+            remaining.discard(todo["id"])
+    if completed:
+        _save_raw(data)
+    return completed, sorted(remaining)
+
+
+def mark_done_overdue() -> list[dict]:
+    """Mark all pending todos whose due_date is in the past as done.
+
+    Returns the list of todos that were marked done.
+    """
+    now = datetime.now(timezone.utc)
+    data = _load_raw()
+    completed = []
+    for todo in data["todos"]:
+        if todo.get("done"):
+            continue
+        raw_due = todo.get("due_date")
+        if not raw_due:
+            continue
+        try:
+            due_dt = datetime.fromisoformat(raw_due)
+            if due_dt.tzinfo is None:
+                due_dt = due_dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+        if due_dt < now:
+            todo["done"] = True
+            completed.append(todo)
+    if completed:
+        _save_raw(data)
+    return completed
+
+
+def delete_todo(todo_id: int) -> dict:
+    data = _load_raw()
+    for i, todo in enumerate(data["todos"]):
+        if todo["id"] == todo_id:
+            removed = data["todos"].pop(i)
+            _save_raw(data)
+            return removed
+    raise KeyError(f"Todo #{todo_id} not found.")
+
+
+def delete_batch(ids: list[int]) -> tuple[list[dict], list[int]]:
+    """Delete multiple todos in a single write.
+
+    Returns (deleted, missing_ids) where missing_ids are IDs not found.
+    """
+    data = _load_raw()
+    id_set = set(ids)
+    deleted = []
+    kept = []
+    for todo in data["todos"]:
+        if todo["id"] in id_set:
+            deleted.append(todo)
+            id_set.discard(todo["id"])
+        else:
+            kept.append(todo)
+    if deleted:
+        data["todos"] = kept
+        _save_raw(data)
+    return deleted, sorted(id_set)
+
+
+def delete_completed() -> list[dict]:
+    """Delete all completed todos. Returns the list of deleted todos."""
+    data = _load_raw()
+    deleted = [t for t in data["todos"] if t["done"]]
+    if deleted:
+        data["todos"] = [t for t in data["todos"] if not t["done"]]
+        _save_raw(data)
+    return deleted

--- a/validator.py
+++ b/validator.py
@@ -1,0 +1,28 @@
+"""Input validation for the todo CLI."""
+
+
+def validate_title(title: str) -> str:
+    """Return stripped title, raising ValueError if blank."""
+    stripped = title.strip()
+    if not stripped:
+        raise ValueError("Todo title cannot be empty.")
+    return stripped
+
+
+def validate_tags(raw_tags: str) -> list[str]:
+    """Parse comma-separated tags, stripping whitespace. Returns empty list for blank input."""
+    if not raw_tags or not raw_tags.strip():
+        return []
+    tags = [t.strip() for t in raw_tags.split(",")]
+    return [t for t in tags if t]
+
+
+def validate_id(raw_id: str) -> int:
+    """Return integer id, raising ValueError if not a positive integer."""
+    try:
+        todo_id = int(raw_id)
+    except (TypeError, ValueError):
+        raise ValueError(f"Invalid id '{raw_id}': must be a positive integer.")
+    if todo_id < 1:
+        raise ValueError(f"Invalid id '{raw_id}': must be a positive integer.")
+    return todo_id


### PR DESCRIPTION
## Summary

- `done --ids 1 2 3` — mark multiple todos done in a single write
- `done --all-overdue` — mark all pending todos whose `due_date` is in the past as done
- `delete --ids 1 2 3` — delete multiple todos in a single write
- `delete --done` — purge all completed todos

Single-ID usage of `done` and `delete` is unchanged.

Batch functions report per-item errors for missing IDs without aborting the whole operation (exit 1 if any IDs were not found).

## Test plan

- [x] `mark_done_batch`: all found → all marked done, missing list empty
- [x] `mark_done_batch`: partial miss → found items marked, missing IDs returned
- [x] `delete_batch`: all found → all deleted
- [x] `delete_batch`: partial miss → found deleted, missing IDs returned
- [x] `delete_completed`: removes all done todos, leaves pending intact
- [x] `mark_done_overdue`: no `due_date` field → not marked done
- [x] `mark_done_overdue`: past `due_date` → marked done
- [x] `mark_done_overdue`: future `due_date` → not touched
- [x] `mark_done_overdue`: already-done todos → skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)