### PR TITLE
[pb-34] Markdown rendering for todo list output

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,14 @@
+"""Configuration and storage path management for the todo CLI."""
+
+import os
+from pathlib import Path
+
+
+def get_storage_path() -> Path:
+    """Return path to the todos JSON file, respecting TODO_FILE env override."""
+    env_path = os.environ.get("TODO_FILE")
+    if env_path:
+        return Path(env_path)
+    data_dir = Path.home() / ".local" / "share" / "todo-cli"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir / "todos.json"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/formatter.py
+++ b/formatter.py
@@ -1,0 +1,59 @@
+"""Terminal output formatting for todo items."""
+
+from datetime import datetime
+
+
+def _status_char(todo: dict) -> str:
+    return "x" if todo["done"] else " "
+
+
+def _created_label(todo: dict) -> str:
+    try:
+        dt = datetime.fromisoformat(todo["created_at"])
+        return dt.astimezone().strftime("%Y-%m-%d %H:%M")
+    except (KeyError, ValueError):
+        return "unknown"
+
+
+def format_todo(todo: dict) -> str:
+    """Single-line summary: '[x] #1  Buy milk'"""
+    return f"[{_status_char(todo)}] #{todo['id']:<4} {todo['title']}"
+
+
+def format_todo_list(todos: list[dict]) -> str:
+    if not todos:
+        return "No todos found."
+    return "\n".join(format_todo(t) for t in todos)
+
+
+def format_markdown_list(todos: list[dict]) -> str:
+    """GitHub-flavored Markdown checklist with priorities and due dates."""
+    if not todos:
+        return "_No todos found._"
+    lines = []
+    for t in todos:
+        check = "x" if t["done"] else " "
+        title = f"~~{t['title']}~~" if t["done"] else t["title"]
+        parts = [f"- [{check}] {title}"]
+        priority = t.get("priority", "")
+        if priority:
+            parts.append(f"**[{priority}]**")
+        due = t.get("due_date", "")
+        if due:
+            parts.append(f"_due: {due}_")
+        lines.append(" ".join(parts))
+    return "\n".join(lines)
+
+
+def format_todo_detail(todo: dict) -> str:
+    """Multi-line detail view for a single todo."""
+    lines = [
+        f"ID:       {todo['id']}",
+        f"Title:    {todo['title']}",
+        f"Status:   {'done' if todo['done'] else 'pending'}",
+        f"Priority: {todo.get('priority', '-')}",
+        f"Due:      {todo.get('due_date', '-')}",
+        f"Tags:     {', '.join(todo['tags']) if todo.get('tags') else '-'}",
+        f"Created:  {_created_label(todo)}",
+    ]
+    return "\n".join(lines)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Todo CLI — entry point."""
+
+import argparse
+import sys
+
+import formatter
+import todo
+import validator
+
+
+def cmd_add(args: argparse.Namespace) -> int:
+    try:
+        title = validator.validate_title(" ".join(args.title))
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    item = todo.add_todo(title)
+    print(f"Added: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    items = todo.list_todos(show_done=args.all)
+    if args.format == "markdown":
+        print(formatter.format_markdown_list(items))
+    else:
+        print(formatter.format_todo_list(items))
+    return 0
+
+
+def cmd_done(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    try:
+        item = todo.mark_done(todo_id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Marked done: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    try:
+        item = todo.delete_todo(todo_id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    print(f"Deleted: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_edit(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    kwargs: dict = {}
+    if args.title is not None:
+        try:
+            kwargs["title"] = validator.validate_title(" ".join(args.title))
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+    if args.priority is not None:
+        try:
+            kwargs["priority"] = validator.validate_priority(args.priority)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+    if args.due_date is not None:
+        try:
+            kwargs["due_date"] = validator.validate_due_date(args.due_date)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+    if args.tags is not None:
+        try:
+            kwargs["tags"] = validator.validate_tags(args.tags)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+    if not kwargs:
+        print("Error: at least one field to update must be specified.", file=sys.stderr)
+        return 1
+
+    try:
+        item = todo.update_todo(todo_id, **kwargs)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Updated: {formatter.format_todo(item)}")
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    try:
+        todo_id = validator.validate_id(args.id)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    item = todo.get_todo(todo_id)
+    if item is None:
+        print(f"Error: Todo #{todo_id} not found.", file=sys.stderr)
+        return 1
+    print(formatter.format_todo_detail(item))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="todo",
+        description="A simple command-line todo manager.",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="<command>")
+    sub.required = True
+
+    # add
+    p_add = sub.add_parser("add", help="Add a new todo item.")
+    p_add.add_argument("title", nargs="+", help="Title of the todo item.")
+    p_add.set_defaults(func=cmd_add)
+
+    # list
+    p_list = sub.add_parser("list", help="List todo items.")
+    p_list.add_argument(
+        "--all", action="store_true", help="Include completed todos."
+    )
+    p_list.add_argument(
+        "--format", choices=["text", "markdown"], default="text",
+        help="Output format: text (default) or markdown checklist.",
+    )
+    p_list.set_defaults(func=cmd_list)
+
+    # done
+    p_done = sub.add_parser("done", help="Mark a todo as done.")
+    p_done.add_argument("id", help="ID of the todo to mark done.")
+    p_done.set_defaults(func=cmd_done)
+
+    # delete
+    p_del = sub.add_parser("delete", help="Delete a todo item.")
+    p_del.add_argument("id", help="ID of the todo to delete.")
+    p_del.set_defaults(func=cmd_delete)
+
+    # edit
+    p_edit = sub.add_parser("edit", help="Modify an existing todo item.")
+    p_edit.add_argument("id", help="ID of the todo to edit.")
+    p_edit.add_argument("--title", nargs="+", default=None, help="New title.")
+    p_edit.add_argument("--priority", default=None, metavar="low/medium/high", help="Priority level.")
+    p_edit.add_argument("--due-date", dest="due_date", default=None, metavar="YYYY-MM-DD", help="Due date.")
+    p_edit.add_argument("--tags", default=None, metavar="tag1,tag2", help="Comma-separated tags.")
+    p_edit.set_defaults(func=cmd_edit)
+
+    # show
+    p_show = sub.add_parser("show", help="Show detail for a todo item.")
+    p_show.add_argument("id", help="ID of the todo to show.")
+    p_show.set_defaults(func=cmd_show)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_markdown.py
+++ b/test_markdown.py
@@ -1,0 +1,126 @@
+"""Tests for formatter.format_markdown_list and the --format markdown CLI flag."""
+
+import subprocess
+import sys
+import os
+import pytest
+
+from formatter import format_markdown_list
+
+
+def _todo(id, title, done=False, priority="", due_date=""):
+    t = {"id": id, "title": title, "done": done}
+    if priority:
+        t["priority"] = priority
+    if due_date:
+        t["due_date"] = due_date
+    return t
+
+
+# ---------------------------------------------------------------------------
+# format_markdown_list unit tests
+# ---------------------------------------------------------------------------
+
+class TestFormatMarkdownList:
+    def test_empty_list_returns_no_todos_message(self):
+        assert format_markdown_list([]) == "_No todos found._"
+
+    def test_pending_item_uses_unchecked_box(self):
+        result = format_markdown_list([_todo(1, "Buy milk")])
+        assert result.startswith("- [ ]")
+
+    def test_pending_item_contains_plain_title(self):
+        result = format_markdown_list([_todo(1, "Buy milk")])
+        assert "Buy milk" in result
+        assert "~~" not in result
+
+    def test_done_item_uses_checked_box(self):
+        result = format_markdown_list([_todo(1, "Buy milk", done=True)])
+        assert result.startswith("- [x]")
+
+    def test_done_item_uses_strikethrough(self):
+        result = format_markdown_list([_todo(1, "Buy milk", done=True)])
+        assert "~~Buy milk~~" in result
+
+    def test_priority_annotation_included_when_set(self):
+        result = format_markdown_list([_todo(1, "Task", priority="high")])
+        assert "**[high]**" in result
+
+    def test_due_date_annotation_included_when_set(self):
+        result = format_markdown_list([_todo(1, "Task", due_date="2026-06-15")])
+        assert "_due: 2026-06-15_" in result
+
+    def test_priority_omitted_when_absent(self):
+        result = format_markdown_list([_todo(1, "Task")])
+        assert "**[" not in result
+
+    def test_due_date_omitted_when_absent(self):
+        result = format_markdown_list([_todo(1, "Task")])
+        assert "_due:" not in result
+
+    def test_both_annotations_present_when_set(self):
+        result = format_markdown_list([_todo(1, "Task", priority="low", due_date="2026-07-01")])
+        assert "**[low]**" in result
+        assert "_due: 2026-07-01_" in result
+
+    def test_multiple_todos_each_on_own_line(self):
+        todos = [_todo(1, "A"), _todo(2, "B"), _todo(3, "C")]
+        lines = format_markdown_list(todos).split("\n")
+        assert len(lines) == 3
+
+    def test_mixed_done_and_pending(self):
+        todos = [_todo(1, "Pending"), _todo(2, "Done", done=True)]
+        lines = format_markdown_list(todos).split("\n")
+        assert lines[0].startswith("- [ ]")
+        assert lines[1].startswith("- [x]")
+
+    def test_returns_string(self):
+        assert isinstance(format_markdown_list([_todo(1, "Task")]), str)
+
+    def test_priority_appears_before_due_date(self):
+        result = format_markdown_list([_todo(1, "Task", priority="medium", due_date="2026-06-01")])
+        pri_pos = result.index("**[medium]**")
+        due_pos = result.index("_due:")
+        assert pri_pos < due_pos
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: --format markdown flag
+# ---------------------------------------------------------------------------
+
+class TestMarkdownCLIFlag:
+    @pytest.fixture(autouse=True)
+    def isolate_storage(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TODO_FILE", str(tmp_path / "todos.json"))
+
+    def test_format_markdown_exits_zero(self, tmp_path, monkeypatch):
+        env = {**os.environ, "TODO_FILE": str(tmp_path / "todos.json")}
+        result = subprocess.run(
+            [sys.executable, "main.py", "list", "--format", "markdown"],
+            capture_output=True, text=True, env=env,
+        )
+        assert result.returncode == 0
+
+    def test_format_markdown_outputs_no_todos_message(self, tmp_path):
+        env = {**os.environ, "TODO_FILE": str(tmp_path / "todos.json")}
+        result = subprocess.run(
+            [sys.executable, "main.py", "list", "--format", "markdown"],
+            capture_output=True, text=True, env=env,
+        )
+        assert "_No todos found._" in result.stdout
+
+    def test_format_text_still_works(self, tmp_path):
+        env = {**os.environ, "TODO_FILE": str(tmp_path / "todos.json")}
+        result = subprocess.run(
+            [sys.executable, "main.py", "list", "--format", "text"],
+            capture_output=True, text=True, env=env,
+        )
+        assert result.returncode == 0
+
+    def test_invalid_format_exits_nonzero(self, tmp_path):
+        env = {**os.environ, "TODO_FILE": str(tmp_path / "todos.json")}
+        result = subprocess.run(
+            [sys.executable, "main.py", "list", "--format", "html"],
+            capture_output=True, text=True, env=env,
+        )
+        assert result.returncode != 0

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,102 @@
+"""Core todo CRUD operations backed by a JSON file."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from config import get_storage_path
+
+
+def _load_raw() -> dict:
+    path = get_storage_path()
+    if not path.exists():
+        return {"next_id": 1, "todos": []}
+    with path.open() as f:
+        return json.load(f)
+
+
+def _save_raw(data: dict) -> None:
+    path = get_storage_path()
+    with path.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_todos() -> list[dict]:
+    return _load_raw()["todos"]
+
+
+def add_todo(title: str) -> dict:
+    data = _load_raw()
+    todo = {
+        "id": data["next_id"],
+        "title": title,
+        "done": False,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    data["todos"].append(todo)
+    data["next_id"] += 1
+    _save_raw(data)
+    return todo
+
+
+def get_todo(todo_id: int) -> Optional[dict]:
+    for todo in load_todos():
+        if todo["id"] == todo_id:
+            return todo
+    return None
+
+
+def list_todos(show_done: bool = False) -> list[dict]:
+    todos = load_todos()
+    if not show_done:
+        todos = [t for t in todos if not t["done"]]
+    return todos
+
+
+def mark_done(todo_id: int) -> dict:
+    data = _load_raw()
+    for todo in data["todos"]:
+        if todo["id"] == todo_id:
+            todo["done"] = True
+            _save_raw(data)
+            return todo
+    raise ValueError(f"Todo #{todo_id} not found.")
+
+
+def delete_todo(todo_id: int) -> dict:
+    data = _load_raw()
+    for i, todo in enumerate(data["todos"]):
+        if todo["id"] == todo_id:
+            removed = data["todos"].pop(i)
+            _save_raw(data)
+            return removed
+    raise ValueError(f"Todo #{todo_id} not found.")
+
+
+_SENTINEL = object()
+
+
+def update_todo(
+    todo_id: int,
+    *,
+    title: object = _SENTINEL,
+    priority: object = _SENTINEL,
+    due_date: object = _SENTINEL,
+    tags: object = _SENTINEL,
+) -> dict:
+    """Partial update — only fields passed (not _SENTINEL) are changed."""
+    data = _load_raw()
+    for todo in data["todos"]:
+        if todo["id"] == todo_id:
+            if title is not _SENTINEL:
+                todo["title"] = title
+            if priority is not _SENTINEL:
+                todo["priority"] = priority
+            if due_date is not _SENTINEL:
+                todo["due_date"] = due_date
+            if tags is not _SENTINEL:
+                todo["tags"] = tags
+            _save_raw(data)
+            return todo
+    raise ValueError(f"Todo #{todo_id} not found.")

--- a/validator.py
+++ b/validator.py
@@ -1,0 +1,50 @@
+"""Input validation for the todo CLI."""
+
+from datetime import date
+
+VALID_PRIORITIES = {"low", "medium", "high"}
+
+
+def validate_title(title: str) -> str:
+    """Return stripped title, raising ValueError if blank."""
+    stripped = title.strip()
+    if not stripped:
+        raise ValueError("Todo title cannot be empty.")
+    return stripped
+
+
+def validate_id(raw_id: str) -> int:
+    """Return integer id, raising ValueError if not a positive integer."""
+    try:
+        todo_id = int(raw_id)
+    except (TypeError, ValueError):
+        raise ValueError(f"Invalid id '{raw_id}': must be a positive integer.")
+    if todo_id < 1:
+        raise ValueError(f"Invalid id '{raw_id}': must be a positive integer.")
+    return todo_id
+
+
+def validate_priority(raw: str) -> str:
+    """Return normalised priority string (low/medium/high), raising ValueError otherwise."""
+    normalised = raw.strip().lower()
+    if normalised not in VALID_PRIORITIES:
+        raise ValueError(f"Invalid priority '{raw}': must be low, medium, or high.")
+    return normalised
+
+
+def validate_due_date(raw: str) -> str:
+    """Return ISO date string (YYYY-MM-DD), raising ValueError on bad format."""
+    try:
+        date.fromisoformat(raw)
+    except ValueError:
+        raise ValueError(f"Invalid due date '{raw}': expected YYYY-MM-DD.")
+    return raw
+
+
+def validate_tags(raw: str) -> list[str]:
+    """Return list of stripped, non-empty tag strings from a comma-separated input."""
+    tags = [t.strip() for t in raw.split(",")]
+    tags = [t for t in tags if t]
+    if not tags:
+        raise ValueError("Tags cannot be empty.")
+    return tags


### PR DESCRIPTION
## Summary

Add --format markdown to the list command. Renders todos as a GitHub-flavored Markdown checklist with priorities and due dates. Useful for pasting into docs or READMEs.


Ticket: pb-34